### PR TITLE
Delete FlashAir files from the command line

### DIFF
--- a/flashair-util
+++ b/flashair-util
@@ -11,7 +11,7 @@ from functools import partial
 from pathlib import Path
 
 from requests import RequestException
-from tfatool import command, sync, info, cgi, util
+from tfatool import command, sync, info, cgi, util, upload
 
 
 logger = logging.getLogger("main")
@@ -32,6 +32,8 @@ actions.add_argument("-S", "--sync-once", default=False,
                      choices=["time", "name", "all"],
                      help="move files (all or by most recent name/timestamp) from "
                           "REMOTE_DIR to LOCAL_DIR, then quit")
+actions.add_argument("--delete",
+                     help="delete a given file (within --remote-dir)")
 
 setup = parser.add_argument_group("Setup")
 setup.add_argument("-y", "--sync-direction", choices=["up", "down", "both"],
@@ -63,6 +65,15 @@ def run():
     args = parser.parse_args()
     if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)
+
+    # delete a file
+    if args.delete:
+        try:
+            upload.delete_file_in(args.delete, remote_dir=args.remote_dir)
+            logger.info("Deleted remote file {} in directory {}".format(
+                        args.delete, args.remote_dir))
+        except RequestException as e:
+            print("\nHTTP request exception: {}".format(e))
 
     # filename filters
     filters = []

--- a/test.py
+++ b/test.py
@@ -28,7 +28,7 @@ def test_invalid_timeout_value():
 def test_valid_timeout_value():
     params = {Config.wifi_timeout: 120.5201}
     assert config(params)["APPAUTOTIME"] == 120520
-    
+
 
 def test_full_config():
     params = {Config.wifi_timeout: 60,
@@ -51,7 +51,7 @@ def test_full_config():
                 'APPMODE': 2, 'APPNETWORKKEY': 'supersecret', 'TIMEZONE': -20,
                 'BRGSSID': 'officewifi', 'CLEARCODE': 1,
                 'MASTERCODE': 'beefbeefbeef'}
-    
+
 
 def test_command_cgi_query():
     req = command._prep_get(command.Operation.list_files, DIR="/DCIM/WOMP")
@@ -66,6 +66,19 @@ def test_command_cgi_url():
     print(req.url)
     url, _ = parse.splitquery(req.url)
     assert url == "http://192.168.0.1/command.cgi"
+
+
+def test_delete_request_url():
+    req = upload._prep_delete_request("ham.png")
+    assert (req.url ==
+            "http://flashair/upload.cgi?DEL=%2FDCIM%2F100__TSB%2Fham.png")
+
+    # From the FlashAir docs
+    # Request Example:
+    # http://flashair/upload.cgi?DEL=/DCIM/100__TSB/DSC_100.JPG
+    expected = "http://flashair/upload.cgi?DEL=/DCIM/100__TSB/DSC_100.JPG"
+    raw_url = upload._prep_delete_request("DSC_100.JPG").url
+    assert raw_url.replace("%2F", "/") == expected
 
 
 def test_datetime_encode_decode():
@@ -91,7 +104,7 @@ def test_datetime_str_encode():
     datetime_val = 0x00340153  # a 32-bit encoded date
     as_string = upload._str_encode_time(datetime_val)
     assert as_string == "0x00340153"
- 
+
 
 def test_upload_post_url():
     docs_url = "http://flashair/upload.cgi?WRITEPROTECT=ON"  # from docs

--- a/test.py
+++ b/test.py
@@ -68,7 +68,7 @@ def test_command_cgi_url():
     assert url == "http://192.168.0.1/command.cgi"
 
 
-def test_delete_request_url():
+def test_delete_request():
     req = upload._prep_delete_request("ham.png")
     assert (req.url ==
             "http://flashair/upload.cgi?DEL=%2FDCIM%2F100__TSB%2Fham.png")
@@ -79,6 +79,15 @@ def test_delete_request_url():
     expected = "http://flashair/upload.cgi?DEL=/DCIM/100__TSB/DSC_100.JPG"
     raw_url = upload._prep_delete_request("DSC_100.JPG").url
     assert raw_url.replace("%2F", "/") == expected
+
+
+def test_delete_request_no_directory():
+    """Make sure the user can specify a `None` remote directory
+    so that they can construct full paths of their own to delete files.
+    """
+    req = upload._prep_delete_request("ham.png", remote_dir=None)
+    assert (req.url ==
+            "http://flashair/upload.cgi?DEL=ham.png")
 
 
 def test_datetime_encode_decode():

--- a/tfatool/cgi.py
+++ b/tfatool/cgi.py
@@ -49,4 +49,3 @@ prep_get = partial(prep_request, "GET")
 get = partial(request, "GET")
 prep_post = partial(prep_request, "POST")
 post = partial(request, "POST")
-

--- a/tfatool/upload.py
+++ b/tfatool/upload.py
@@ -20,14 +20,15 @@ def upload_file(local_path: str, url=URL, remote_dir=DEFAULT_REMOTE_DIR):
     set_write_protect(WriteProtectMode.off, url=url)
 
 
-def delete_file(remote_filepath: str, url: str = URL,
-                remote_dir: Optional[str] = DEFAULT_REMOTE_DIR):
+def delete_file_in(remote_filepath: str, url: str = URL,
+                   remote_dir: Optional[str] = DEFAULT_REMOTE_DIR):
     """
     Delete `remote_filepath` from the FlashAir device at `url`.
     If `remote_dir` is specified, the complete path to the resource to
     be deleted will be the joining of `remote_dir` and `remote_filepath`.
-    By default, `remote_dir` is the FlashAir default directory, so the most common
-    usage of this function is `delete_file("my_file.jpg").
+    By default, `remote_dir` is the FlashAir default directory,
+    so the most common usage of this function is
+    `delete_file_in("my_file.jpg")`.
 
     If `remote_dir` is None, `remote_filepath` will be used as the full path
     to the resource to be deleted.
@@ -39,10 +40,15 @@ def delete_file(remote_filepath: str, url: str = URL,
     file system.'
     """
     delete_request = _prep_delete_request(remote_filepath, url, remote_dir)
-    response = cgi.post(delete_request)
+    response = cgi.send(delete_request)
     if response.text != ResponseCode.success:
         raise UploadError("Failed to delete file", response)
     return response
+
+
+# Partially applied delete_file_in with no remote_dir
+# Call this when you know the exact path of the file you're deleting
+delete_file = partial(delete_file_in, remote_dir=None)
 
 
 def _prep_delete_request(
@@ -84,13 +90,6 @@ def post_file(local_path: str, url=URL):
     response = post(url=url, req_kwargs=dict(files=files))
     if response.status_code != 200:
         raise UploadError("Failed to post file", response)
-    return response
-
-
-def delete_file(remote_file: str, url=URL):
-    response = get(url=url, **{Upload.delete: remote_file})
-    if response.status_code != 200:
-        raise UploadError("Failed to delete file", response)
     return response
 
 

--- a/tfatool/upload.py
+++ b/tfatool/upload.py
@@ -3,11 +3,13 @@ import os
 import arrow
 
 from functools import partial
+from pathlib import PosixPath
+from typing import Optional
 
 from . import cgi
 from .info import DEFAULT_REMOTE_DIR, DEFAULT_MASTERCODE, URL
 from .info import WriteProtectMode, Upload, ResponseCode
-from requests import RequestException
+from requests import RequestException, Request
 
 
 def upload_file(local_path: str, url=URL, remote_dir=DEFAULT_REMOTE_DIR):
@@ -16,6 +18,41 @@ def upload_file(local_path: str, url=URL, remote_dir=DEFAULT_REMOTE_DIR):
     set_creation_time(local_path, url=url)
     post_file(local_path, url=url)
     set_write_protect(WriteProtectMode.off, url=url)
+
+
+def delete_file(remote_filepath: str, url: str = URL,
+                remote_dir: Optional[str] = DEFAULT_REMOTE_DIR):
+    """
+    Delete `remote_filepath` from the FlashAir device at `url`.
+    If `remote_dir` is specified, the complete path to the resource to
+    be deleted will be the joining of `remote_dir` and `remote_filepath`.
+    By default, `remote_dir` is the FlashAir default directory, so the most common
+    usage of this function is `delete_file("my_file.jpg").
+
+    If `remote_dir` is None, `remote_filepath` will be used as the full path
+    to the resource to be deleted.
+
+    A note from the FlashAir docs:
+    'Important: If you delete a directory, be sure that it does not
+    contain child directories or files. If you delete a parent directory,
+    its child directories and files may no longer be recognized by the
+    file system.'
+    """
+    delete_request = _prep_delete_request(remote_filepath, url, remote_dir)
+    response = cgi.post(delete_request)
+    if response.text != ResponseCode.success:
+        raise UploadError("Failed to delete file", response)
+    return response
+
+
+def _prep_delete_request(
+        remote_filepath: str, url: str = URL,
+        remote_dir: Optional[str] = DEFAULT_REMOTE_DIR) -> Request:
+    if remote_dir is None:
+        full_remote_path = remote_filepath
+    else:
+        full_remote_path = str(PosixPath(remote_dir, remote_filepath))
+    return prep_post(url, **{Upload.delete: full_remote_path})
 
 
 def set_write_protect(mode: WriteProtectMode, url=URL):


### PR DESCRIPTION
# Delete files via `flashair-util`
Previously, the `upload` entrypoint's `DEL` was used internally to sync directories with FlashAir. @thopiekar has requested (issue #8) that deletion be a first class citizen.

# Help! This needs functional testing!
I no longer have a FlashAir SD card, so I'd appreciate it if somebody could help me test this! Ambitious contributors might also add a small test to `test_functional.py`.

# How to use this (from the command line)
```bash
$ flashair-util --delete hork.jpg  # delete hork.jpg in the default /DCIM/100__TSB directory
$ flashair-util --delete /path/to/hork.jpg -r ''  # if you know your absolute remote path, make the remote directory blank
```

# How to use this (in your code)
```python
from tfatool import upload

# delete a remote file in the default directory
upload.delete_file_in("hork.png")

# delete a remote file in another directory
upload.delete_file_in("hork.png", remote_dir="/DCIM/special_dir/")

# delete a remote file with a fully specified, absolute path
upload.delete_file_in("/DCIM/special_dir/hork.jpg", remote_dir=None)

# use `delete_file` as a shortcut for `upload.delete_file_in(..., remote_dir=None)`
upload.delete_file("/DCIM/special_dir/hork.jpg")  # the same as the above call
```

# How this was tested
Very minimal unit testing for request URL construction and some command line usage.