### PR TITLE
Make everything work through a connection context

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ while `flashair-config` lets the user configure the the deivce.
 * `tfatool.upload`: abstraction of FlashAir's [upload.cgi](https://flashair-developers.com/en/documents/api/uploadcgi/)
 * `tfatool.config`: abstraction of FlashAir's [config.cgi](https://flashair-developers.com/en/documents/api/configcgi/)
 * `tfatool.sync`: functions for synchronizing local dirs with remote FlashAir dirs
+* `tfatool.session`: a `Session` object for managing the state of your connection to FlashAir (filters, URLs, and local/remote directories)
 
 Read the [FlashAir documentation](https://flashair-developers.com/en/documents/api/)
 for more information about the API `tfatool` uses.
@@ -47,11 +48,10 @@ for more information about the API `tfatool` uses.
 ### Help menu
 
 ```
-$ flashair-util -h
 usage: flashair-util [-h] [-v] [-l] [-c] [-s] [-S {time,name,all}]
-                     [-y {up,down,both}] [-r REMOTE_DIR] [-d LOCAL_DIR] [-j]
-                     [-n N_FILES] [-k MATCH_REGEX] [-t EARLIEST_DATE]
-                     [-T LATEST_DATE]
+                     [-y {up,down,both}] [-r REMOTE_DIR] [-d LOCAL_DIR]
+                     [-u URL] [-j] [-n N_FILES] [-k MATCH_REGEX]
+                     [-t EARLIEST_DATE] [-T LATEST_DATE]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -75,6 +75,7 @@ Setup:
                         /DCIM/100__TSB)
   -d LOCAL_DIR, --local-dir LOCAL_DIR
                         local directory to work with (default: working dir)
+  -u URL, --url URL     URL of your FlashAir device (must start with http://)
 
 File filters:
   -j, --only-jpg        filter for only JPEG files

--- a/flashair-config
+++ b/flashair-config
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
 import logging
-from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+from argparse import ArgumentParser
 from tfatool import config, command, cgi, info
+from tfatool.session import Session
 from requests import RequestException
 
 
@@ -17,6 +18,9 @@ parser.add_argument("-m", "--mastercode", default="BEEFBEEFBEEF",
                     help="12-digit hex mastercode to enable configuration "
                          "of the FlashAir device")
 parser.add_argument("-v", "--verbose", action="store_true")
+parser.add_argument("-u", "--url", default=info.URL,
+                    help="URL of your FlashAir device "
+                         "(must start with http://)")
 
 wifi = parser.add_argument_group("WiFi settings")
 wifi.add_argument("-t", "--wifi-timeout", help="set WiFi timeout of device",
@@ -51,6 +55,7 @@ show.add_argument("--show-wifi-mode", action="store_true")
 
 def run():
     args = parser.parse_args()
+    session = Session(url=args.url)
     if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)
 
@@ -72,21 +77,22 @@ def run():
     cgi_params = config.config(params)
     if len(list(cgi_params.keys())) > 1:
         logger.info("CGI params: {}".format(cgi_params))
-        response = config.post(cgi_params)
+        response = config.post(cgi_params, session=session)
         logger.info("Response: {}".format(response.status_code))
 
     # show config params with a GET
     if args.show_wifi_ssid:
-        print("SSID: {}".format(command.get_ssid()))
+        print("SSID: {}".format(command.get_ssid(session)))
     if args.show_wifi_key:
-        print("WiFi key: {}".format(command.get_password()))
+        print("WiFi key: {}".format(command.get_password(session)))
     if args.show_mac:
-        print("MAC address: {}".format(command.get_mac()))
+        print("MAC address: {}".format(command.get_mac(session)))
     if args.show_fw_version:
-        print("Firmware version: {}".format(command.get_fw_version()))
+        print("Firmware version: {}".format(command.get_fw_version(session)))
     if args.show_wifi_mode:
-        mode = command.get_wifi_mode()
+        mode = command.get_wifi_mode(session)
         print("WiFi mode: {} ({:d})".format(mode.name, mode.value))
+
 
 if __name__ == "__main__":
     with cgi.session:
@@ -94,4 +100,3 @@ if __name__ == "__main__":
             run()
         except RequestException as e:
             print("\nHTTP request exception: {}".format(e))
-

--- a/flashair-util
+++ b/flashair-util
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-#coding: UTF-8
+# coding: UTF-8
 
 import logging
 import re
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from requests import RequestException
 from tfatool import command, sync, info, cgi, util
+from tfatool.session import Session
 
 
 logger = logging.getLogger("main")
@@ -26,12 +27,12 @@ actions = parser.add_argument_group("Actions")
 actions.add_argument("-l", "--list-files", action="store_true")
 actions.add_argument("-c", "--count-files", action="store_true")
 actions.add_argument("-s", "--sync-forever", action="store_true",
-                     help="watch for new files in REMOTE_DIR, copy them to LOCAL_DIR "
-                          "(runs until CTRL-C)")
+                     help="watch for new files in REMOTE_DIR, copy them to "
+                          "LOCAL_DIR (runs until CTRL-C)")
 actions.add_argument("-S", "--sync-once", default=False,
                      choices=["time", "name", "all"],
-                     help="move files (all or by most recent name/timestamp) from "
-                          "REMOTE_DIR to LOCAL_DIR, then quit")
+                     help="move files (all or by most recent name/timestamp) "
+                          "from REMOTE_DIR to LOCAL_DIR, then quit")
 
 setup = parser.add_argument_group("Setup")
 setup.add_argument("-y", "--sync-direction", choices=["up", "down", "both"],
@@ -43,20 +44,23 @@ setup.add_argument("-r", "--remote-dir", default=info.DEFAULT_REMOTE_DIR,
                         info.DEFAULT_REMOTE_DIR))
 setup.add_argument("-d", "--local-dir", default=".",
                    help="local directory to work with (default: working dir)")
+setup.add_argument("-u", "--url", default=info.URL,
+                   help="URL of your FlashAir device "
+                        "(must start with http://)")
 
 filt = parser.add_argument_group("File filters")
 filt.add_argument("-j", "--only-jpg", action="store_true",
-                   help="filter for only JPEG files")
-filt.add_argument("-n","--n-files", type=int, default=1,
-                   help="Number of files to move in --sync-once mode")
+                  help="filter for only JPEG files")
+filt.add_argument("-n", "--n-files", type=int, default=1,
+                  help="Number of files to move in --sync-once mode")
 filt.add_argument("-k", "--match-regex", default=None,
-                   help="filter for files that match the given pattern")
+                  help="filter for files that match the given pattern")
 filt.add_argument("-t", "--earliest-date",
-                   help="work on only files AFTER datetime of any "
-                        "reasonable format such as YYYY, YYYY-MM, "
-                        "MM/DD, HH:mm (today), or 'YYYY-MM-DD HH:mm:ss'")
+                  help="work on only files AFTER datetime of any "
+                       "reasonable format such as YYYY, YYYY-MM, "
+                       "MM/DD, HH:mm (today), or 'YYYY-MM-DD HH:mm:ss'")
 filt.add_argument("-T", "--latest-date",
-                   help="work on only files BEFORE given datetime")
+                  help="work on only files BEFORE given datetime")
 
 
 def run():
@@ -67,10 +71,12 @@ def run():
     # filename filters
     filters = []
     if args.only_jpg:
-        jpg_filter = lambda f: f.filename.lower().endswith(".jpg")
+        def jpg_filter(fileinfo) -> bool:
+            return fileinfo.filename.lower().endswith(".jpg")
         filters.append(jpg_filter)
     if args.match_regex:
-        regex_filter = lambda f: re.match(args.match_regex, f.filename)
+        def regex_filter(fileinfo) -> bool:
+            return re.match(args.match_regex, fileinfo.filename)
         filters.append(regex_filter)
 
     # datetme filters
@@ -96,28 +102,36 @@ def run():
             late = latest_date.format("YYYY-MM-DD HH:mm:ss")
         logger.info("Filtering from [{}] to [{}]".format(early, late))
 
+    # create a session.Session object based on given args
+    session = Session(url=args.url,
+                      local_dir=args.local_dir,
+                      remote_dir=args.remote_dir,
+                      filters=tuple(filters))
+
+    # carry out actions in the actions group
     try:
         if args.list_files:
-            print_file_list(filters, args)
+            print_file_list(session)
         if args.count_files:
-            print_file_count(filters, args)
+            print_file_count(session)
     except RequestException as e:
         print("\nHTTP request exception: {}".format(e))
 
     if args.sync_once == "all" and args.n_files != 1:
-        parser.error("`--sync-once all` doesn't make sense with `--num-files N`")
+        parser.error("`--sync-once all` doesn't make sense with "
+                     "`--num-files N`")
 
     if args.sync_forever or args.sync_once:
-        local_path = Path(args.local_dir)
+        local_path = Path(session.local_dir)
         if not local_path.is_dir():
-            logger.info("Creating directory '{}'".format(args.local_dir))
+            logger.info("Creating directory '{}'".format(session.local_dir))
             local_path.mkdir()
         if args.sync_once:
             methods = iter_sync_once_methods(args)
-            sync_once(methods, filters, args)
+            sync_once(methods, session, count=args.n_files)
         if args.sync_forever:
             try:
-                sync_loop(filters, args)
+                sync_loop(session, args)
             except KeyboardInterrupt:
                 pass
 
@@ -139,23 +153,22 @@ def iter_sync_once_methods(args):
             yield sync.down_by_all
 
 
-def sync_once(methods, filters, args):
+def sync_once(methods, session, count):
     for by_method in methods:
         try:
-            by_method(*filters, remote_dir=args.remote_dir,
-                      local_dir=args.local_dir, count=args.n_files)
+            by_method(session=session, count=count)
         except KeyboardInterrupt:
             break
 
 
-def sync_loop(filters, args):
+def sync_loop(session, args):
     try:
-        _sync_loop(filters, args)
+        _sync_loop(session, args)
     except KeyboardInterrupt:
         pass
 
 
-def _sync_loop(filters, args):
+def _sync_loop(session, args):
     if args.sync_direction == "both":
         run_method = sync.up_down_by_arrival
     elif args.sync_direction == "up":
@@ -164,9 +177,7 @@ def _sync_loop(filters, args):
         run_method = sync.down_by_arrival
 
     while True:
-        new_files = run_method(
-            *filters, local_dir=args.local_dir,
-            remote_dir=args.remote_dir)
+        new_files = run_method(session=session)
         logger.info("Waiting for newly arrived files...")
         try:
             while True:
@@ -183,12 +194,12 @@ def _sync_loop(filters, args):
 _fields = ["filename", "date", "time", "MB", "created"]
 
 
-def print_file_list(filters, args, count_only=False):
-    files = command.list_files(*filters, remote_dir=args.remote_dir)
+def print_file_list(session, count_only=False):
+    files = command.list_files(session)
     files = list(files)
     rows = util.fmt_file_rows(files)
     table = tabulate.tabulate(rows, headers=_fields, tablefmt="simple")
-    print("\nFiles in {}".format(args.remote_dir))
+    print("\nFiles in {}".format(session.remote_dir))
     if not count_only:
         print()
         print(table)
@@ -197,7 +208,7 @@ def print_file_list(filters, args, count_only=False):
     size, units = util.get_size_units(nbytes)
     print("({:d} files, {:0.2f} {} total)".format(
           len(files), size, units))
-    
+
 
 print_file_count = partial(print_file_list, count_only=True)
 
@@ -205,4 +216,3 @@ print_file_count = partial(print_file_list, count_only=True)
 if __name__ == "__main__":
     with cgi.session:
         run()
- 

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ classifiers = [
 install_requires = ["requests>=2.9.0", "tqdm>=3.7.1", "arrow", "tabulate"]
 if sys.version_info < (3, 5):
     install_requires.append("scandir")
+    install_requires.append("typing")
 
 setup(name="tfatool",
       version=tfatool._version.__version__,
@@ -121,7 +122,7 @@ setup(name="tfatool",
       package_data={"": ["README.md"]},
       author="Tad Leonard",
       author_email="tadfleonard@gmail.com",
-      keywords="wireless sd card sdcard sync toshiba flashair", 
+      keywords="wireless sd card sdcard sync toshiba flashair",
       url=url,
       download_url=download,
       zip_safe=False,

--- a/test.py
+++ b/test.py
@@ -6,7 +6,7 @@ from urllib import parse
 from tfatool.info import Config, WifiMode, DriveMode
 from tfatool.info import Upload, WriteProtectMode
 from tfatool.config import config
-from tfatool import command, upload, util, sync
+from tfatool import command, upload, util, sync, session
 
 
 def test_config_construction():
@@ -28,7 +28,7 @@ def test_invalid_timeout_value():
 def test_valid_timeout_value():
     params = {Config.wifi_timeout: 120.5201}
     assert config(params)["APPAUTOTIME"] == 120520
-    
+
 
 def test_full_config():
     params = {Config.wifi_timeout: 60,
@@ -51,7 +51,7 @@ def test_full_config():
                 'APPMODE': 2, 'APPNETWORKKEY': 'supersecret', 'TIMEZONE': -20,
                 'BRGSSID': 'officewifi', 'CLEARCODE': 1,
                 'MASTERCODE': 'beefbeefbeef'}
-    
+
 
 def test_command_cgi_query():
     req = command._prep_get(command.Operation.list_files, DIR="/DCIM/WOMP")
@@ -91,12 +91,19 @@ def test_datetime_str_encode():
     datetime_val = 0x00340153  # a 32-bit encoded date
     as_string = upload._str_encode_time(datetime_val)
     assert as_string == "0x00340153"
- 
+
 
 def test_upload_post_url():
     docs_url = "http://flashair/upload.cgi?WRITEPROTECT=ON"  # from docs
-    wp = upload.prep_post(**{Upload.write_protect:
-                             WriteProtectMode.on})
+    wp = upload.prep_post(**{Upload.write_protect: WriteProtectMode.on})
+    assert docs_url == wp.url
+
+
+def test_upload_post_custom_url():
+    docs_url = "http://10.10.3.1/upload.cgi?WRITEPROTECT=ON"  # from docs
+    special_session = session.Session(url="10.10.3.1")
+    wp = upload.prep_post(**{Upload.write_protect: WriteProtectMode.on},
+                          session=special_session)
     assert docs_url == wp.url
 
 

--- a/tfatool/cgi.py
+++ b/tfatool/cgi.py
@@ -27,7 +27,7 @@ def request(method, entrypoint: Entrypoint, url=URL,
     prepared_req = prep_request(method, entrypoint, url=url,
                                 req_kwargs=req_kwargs, **params)
     send_kwargs = send_kwargs or {}
-    return send(prepared_request, **send_kwargs)
+    return send(prepared_req, **send_kwargs)
 
 
 def prep_request(method, entrypoint, url=URL, req_kwargs=None, **params):
@@ -49,4 +49,3 @@ prep_get = partial(prep_request, "GET")
 get = partial(request, "GET")
 prep_post = partial(prep_request, "POST")
 post = partial(request, "POST")
-

--- a/tfatool/config.py
+++ b/tfatool/config.py
@@ -1,8 +1,8 @@
-import logging
 from functools import partial
 from . import cgi
-from .info import URL, DEFAULT_MASTERCODE
+from .info import DEFAULT_MASTERCODE
 from .info import WifiMode, WifiModeOnBoot, ModeValue, DriveMode, Config
+from .session import Session
 
 
 def config(param_map, mastercode=DEFAULT_MASTERCODE):
@@ -21,10 +21,10 @@ def _process_params(params):
         yield param.value, value_validators[param](value)
 
 
-def post(param_map, url=URL):
+def post(param_map, session: Session = Session()):
     """Posts a `param_map` created with `config` to
     the FlashAir config.cgi entrypoint"""
-    prepped_request = _prep_post(url=url, **param_map)
+    prepped_request = _prep_post(url=session.url, **param_map)
     return cgi.send(prepped_request)
 
 
@@ -62,7 +62,7 @@ def _validate_app_info(info: str):
 @_validator(Config.wifi_mode)
 def _validate_wifi_mode(mode: ModeValue):
     assert mode in WifiMode or mode in WifiModeOnBoot
-    return int(mode) 
+    return int(mode)
 
 
 @_validator(Config.wifi_key)
@@ -121,4 +121,3 @@ def _validate_timezone(hours_offset: int):
 def _validate_drive_mode(mode: DriveMode):
     assert mode in DriveMode
     return int(mode)
-

--- a/tfatool/info.py
+++ b/tfatool/info.py
@@ -43,10 +43,11 @@ class Config(str, Enum):
     clear_mastercode = "CLEARCODE"  # clear mastercode
     timezone = "TIMEZONE"  # set timezone (e.g. 36)
     drive_mode = "WEBDAV"  # set FlashAir drive (WebDAV)
-    
 
-class ModeValue(int, Enum): ...
- 
+
+class ModeValue(int, Enum):
+    ...
+
 
 class WifiMode(ModeValue):
     """Wireless modes effective IMMEDIATELY"""
@@ -85,5 +86,3 @@ class WriteProtectMode(str, Enum):
 class ResponseCode(str, Enum):
     success = "SUCCESS"
     error = "ERROR"
-
-

--- a/tfatool/session.py
+++ b/tfatool/session.py
@@ -1,0 +1,97 @@
+from contextlib import contextmanager
+from typing import NamedTuple, Tuple, Callable
+
+from .info import URL, DEFAULT_REMOTE_DIR
+
+
+class _Session(NamedTuple):
+    url: str = URL  # device URL (http://flashair by default)
+    remote_dir: str = DEFAULT_REMOTE_DIR  # /DCIM/100__TSB by default
+    local_dir: str = "."  # local directory for sychronizing files
+    filters: Tuple[Callable] = ()
+
+
+class Session:
+    """Context-mutable wrapper for the _Session namedtuple"""
+
+    def __init__(self, *args, **kwargs):
+        """Creates a _Session namedtuple. See _Session
+        docs for detailed signature."""
+        self._session = _Session(*args, **kwargs)
+
+    @property
+    def url(self):
+        return self._session.url
+
+    @property
+    def remote_dir(self):
+        return self._session.remote_dir
+
+    @property
+    def local_dir(self):
+        return self._session.local_dir
+
+    @property
+    def filters(self):
+        return self._session.filters
+
+    @contextmanager
+    def added_filters(self, *filters: Tuple[Callable]):
+        """Filter with the given callables within a context manager.
+        Applies existing filters in addition to these new ones.
+
+        >>> sesh = session.Session(url="http://hork",
+        ...                        filters=(lamda f: f.size > 3e6,))
+        >>> with sesh.also_filtered(lambda f: f.name.endswith("jpg"):
+        ...     local_large_jpgs = sync.list_local_files(sesh)
+        >>> local_large_files = sync.list_local_files(sesh)
+        """
+        old_session = self._session
+        try:
+            self._session = old_session._replace(
+                filters=filters + old_session.filters)
+            yield
+        finally:
+            self._session = old_session
+
+    @contextmanager
+    def filtered(self, *filters: Tuple[Callable]):
+        """Filter with the given callables within a context manager
+
+        >>> sesh = session.Session(url="http://hork",
+        ...                        filters=(lamda f: f.size > 3e6,))
+        >>> with sesh.filtered(lambda f: f.name.endswith("jpg"):
+        ...     local_jpgs = sync.list_local_files(sesh)
+        >>> local_large_files = sync.list_local_files(sesh)
+        """
+        old_session = self._session
+        try:
+            self._session = self._session._replace(filters=filters)
+            yield
+        finally:
+            self._session = old_session
+
+    @contextmanager
+    def transferring_to(self, local_dir: str = None,
+                        remote_dir: str = None, url: str = None):
+        """Temporarily transfer to a different local dir, remote dir,
+        and/or FlashAir device URL within a context manager.
+
+        >>> sesh = session.Session(url="http://device0")
+        >>> with sesh.transferring_to(url="http://device1"):
+        ...     for _, new_file in sync.up_by_arrival(sesh):
+        ...         ...  # this new file is going to http://device1
+        >>> for _, new_file in sync.up_by_arrival(sesh):
+        ...     ...  # this new file is going to http://device0
+        """
+        old_session = self._session
+        try:
+            local = (local_dir if local_dir is not None else
+                     old_session.local_dir)
+            remote = (remote_dir if remote_dir is not None else
+                      old_session.remote_dir)
+            self._session = self._session._replace(
+                local_dir=local, remote_dir=remote)
+            yield
+        finally:
+            self._session = old_session

--- a/tfatool/sync.py
+++ b/tfatool/sync.py
@@ -6,6 +6,7 @@ import time
 from enum import Enum
 from functools import partial
 from pathlib import Path
+from typing import List, Dict, Optional, Iterable
 from urllib.parse import urljoin
 
 import arrow
@@ -13,8 +14,8 @@ import requests
 import tqdm
 
 from . import command, upload
-from .info import URL, DEFAULT_REMOTE_DIR
-from .info import RawFileInfo, SimpleFileInfo
+from .info import RawFileInfo, SimpleFileInfo, FileInfo
+from .session import Session
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -40,11 +41,8 @@ class Monitor:
     """Synchronizes newly created files TO or FROM FlashAir
     in separate threads"""
 
-    def __init__(self, *filters, local_dir=".",
-                 remote_dir=DEFAULT_REMOTE_DIR):
-        self._filters = filters
-        self._local_dir = local_dir
-        self._remote_dir = remote_dir
+    def __init__(self, session: Session = Session()):
+        self.session = session
         self.running = threading.Event()
         self.thread = None
 
@@ -55,8 +53,7 @@ class Monitor:
         self.thread.start()
 
     def _run_sync(self, method):
-        files = method(*self._filters, local_dir=self._local_dir,
-                       remote_dir=self._remote_dir)
+        files = method(self.session)
         while self.running.is_set():
             _, new = next(files)
             if not new:
@@ -80,16 +77,17 @@ class Monitor:
         self.thread = None
 
 
-def up_down_by_arrival(*filters, local_dir=".",
-                       remote_dir=DEFAULT_REMOTE_DIR):
+def up_down_by_arrival(session: Session = Session()):
     """Monitors a local directory and a remote FlashAir directory and
     generates sets of new files to be uploaded or downloaded.
     Sets to upload are generated in a tuple
     like (Direction.up, {...}), while download sets to download
     are generated in a tuple like (Direction.down, {...}). The generator yields
     before each upload or download actually takes place."""
-    local_monitor = watch_local_files(*filters, local_dir=local_dir)
-    remote_monitor = watch_remote_files(*filters, remote_dir=remote_dir)
+    local_dir = session.local_dir
+    remote_dir = session.remote_dir
+    local_monitor = watch_local_files(session)
+    remote_monitor = watch_remote_files(session)
     _, lfile_set = next(local_monitor)
     _, rfile_set = next(remote_monitor)
     _notify_sync_ready(len(lfile_set), local_dir, remote_dir)
@@ -97,52 +95,59 @@ def up_down_by_arrival(*filters, local_dir=".",
     processed = set()
     for new_local, new_remote in zip(local_monitor, remote_monitor):
         new_local, local_set = new_local
-        local_arrivals = {f for f in new_local if f.filename not in processed}
+        local_arrivals = {f for f in new_local if
+                          f.filename not in processed}
         yield Direction.up, local_arrivals
         if local_arrivals:
-            new_names.update(f.filename for f in local_arrivals)
+            processed.update(f.filename for f in local_arrivals)
             _notify_sync(Direction.up, local_arrivals)
             up_by_files(local_arrivals, remote_dir)
             _notify_sync_ready(len(local_set), local_dir, remote_dir)
         new_remote, remote_set = new_remote
-        remote_arrivals = {f for f in new_remote if f.filename not in processed}
+        remote_arrivals = {f for f in new_remote if
+                           f.filename not in processed}
         yield Direction.down, remote_arrivals
         if remote_arrivals:
-            new_names.update(f.filename for f in remote_arrivals)
+            processed.update(f.filename for f in remote_arrivals)
             _notify_sync(Direction.down, remote_arrivals)
             yield Direction.down, remote_arrivals
-            down_by_files(remote_arrivals, local_dir)
+            down_by_files(remote_arrivals, session)
             _notify_sync_ready(len(remote_set), remote_dir, local_dir)
 
 
-def up_by_arrival(*filters, local_dir=".", remote_dir=DEFAULT_REMOTE_DIR):
+def up_by_arrival(session: Session = Session()):
     """Monitors a local directory and
     generates sets of new files to be uploaded to FlashAir.
     Sets to upload are generated in a tuple like (Direction.up, {...}).
     The generator yields before each upload actually takes place."""
-    local_monitor = watch_local_files(*filters, local_dir=local_dir)
+    local_dir = session.local_dir
+    remote_dir = session.remote_dir
+    local_monitor = watch_local_files(session)
     _, file_set = next(local_monitor)
-    _notify_sync_ready(len(file_set), local_dir, remote_dir)
+    _notify_sync_ready(len(file_set), session.local_dir, remote_dir)
     for new_arrivals, file_set in local_monitor:
-        yield Direction.up, new_arrivals  # where new_arrivals is possibly empty
+        # where new_arrivals is possibly empty
+        yield Direction.up, new_arrivals
         if new_arrivals:
             _notify_sync(Direction.up, new_arrivals)
             up_by_files(new_arrivals, remote_dir)
             _notify_sync_ready(len(file_set), local_dir, remote_dir)
 
 
-def down_by_arrival(*filters, local_dir=".", remote_dir=DEFAULT_REMOTE_DIR):
+def down_by_arrival(session: Session = Session()):
     """Monitors a remote FlashAir directory and generates sets of
     new files to be downloaded from FlashAir.
     Sets to download are generated in a tuple like (Direction.down, {...}).
     The generator yields AFTER each download actually takes place."""
-    remote_monitor = watch_remote_files(*filters, remote_dir=remote_dir)
+    local_dir = session.local_dir
+    remote_dir = session.remote_dir
+    remote_monitor = watch_remote_files(session)
     _, file_set = next(remote_monitor)
     _notify_sync_ready(len(file_set), remote_dir, local_dir)
     for new_arrivals, file_set in remote_monitor:
         if new_arrivals:
             _notify_sync(Direction.down, new_arrivals)
-            down_by_files(new_arrivals, local_dir)
+            down_by_files(new_arrivals, session)
             _notify_sync_ready(len(file_set), remote_dir, local_dir)
         yield Direction.down, new_arrivals
 
@@ -150,36 +155,39 @@ def down_by_arrival(*filters, local_dir=".", remote_dir=DEFAULT_REMOTE_DIR):
 ###################################################
 # Sync ONCE in the DOWN (from FlashAir) direction
 
-def down_by_all(*filters, remote_dir=DEFAULT_REMOTE_DIR, local_dir=".", **_):
-    files = command.list_files(*filters, remote_dir=remote_dir)
-    down_by_files(files, local_dir=local_dir)
+def down_by_all(session: Session = Session()):
+    files = command.list_files(session)
+    down_by_files(files, session)
 
 
-def down_by_files(to_sync, local_dir="."):
-    """Sync a given list of files from `command.list_files` to `local_dir` dir"""
-    for f in to_sync:
-        _sync_remote_file(local_dir, f)
+def down_by_files(to_sync: List[FileInfo],
+                  session: Session = Session()):
+    """Sync a given list of files from `command.list_files`
+    to `session.local_dir` dir"""
+    for fileinfo in to_sync:
+        _sync_remote_file(fileinfo, session)
 
 
-def down_by_time(*filters, remote_dir=DEFAULT_REMOTE_DIR, local_dir=".", count=1):
+def down_by_time(session: Session = Session(), count=1):
     """Sync most recent file by date, time attribues"""
-    files = command.list_files(*filters, remote_dir=remote_dir)
+    files = command.list_files(session)
     most_recent = sorted(files, key=lambda f: f.datetime)
     to_sync = most_recent[-count:]
     _notify_sync(Direction.down, to_sync)
-    down_by_files(to_sync[::-1], local_dir=local_dir)
+    down_by_files(to_sync[::-1], session)
 
 
-def down_by_name(*filters, remote_dir=DEFAULT_REMOTE_DIR, local_dir=".", count=1):
+def down_by_name(session: Session = Session(), count=1):
     """Sync files whose filename attribute is highest in alphanumeric order"""
-    files = command.list_files(*filters, remote_dir=remote_dir)
+    files = command.list_files(session)
     greatest = sorted(files, key=lambda f: f.filename)
     to_sync = greatest[-count:]
     _notify_sync(Direction.down, to_sync)
-    down_by_files(to_sync[::-1], local_dir=local_dir)
+    down_by_files(to_sync[::-1], session)
 
 
-def _sync_remote_file(local_dir, remote_file_info):
+def _sync_remote_file(remote_file_info: FileInfo, session: Session):
+    local_dir = session.local_dir
     local = Path(local_dir, remote_file_info.filename)
     local_name = str(local)
     remote_size = remote_file_info.size
@@ -187,27 +195,26 @@ def _sync_remote_file(local_dir, remote_file_info):
         local_size = local.stat().st_size
         if local.stat().st_size == remote_size:
             logger.info(
-                "Skipping '{}': already exists locally".format(
-                local_name))
+                "Skipping '{}': already exists locally".format(local_name))
         else:
             logger.warning(
                 "Removing {}: local size {} != remote size {}".format(
-                local_name, local_size, remote_size))
+                    local_name, local_size, remote_size))
             os.remove(local_name)
-            _stream_to_file(local_name, remote_file_info)
+            _stream_to_file(local_name, remote_file_info, session)
     else:
-        _stream_to_file(local_name, remote_file_info)
+        _stream_to_file(local_name, remote_file_info, session)
 
 
-def _stream_to_file(local_name, fileinfo):
+def _stream_to_file(local_name, fileinfo, session):
     logger.info("Copying remote file {} to {}".format(
                 fileinfo.path, local_name))
-    streaming_file = _get_file(fileinfo)
+    streaming_file = _get_file(fileinfo, session)
     _write_file_safely(local_name, fileinfo, streaming_file)
 
 
-def _get_file(fileinfo):
-    url = urljoin(URL, fileinfo.path)
+def _get_file(fileinfo, session):
+    url = urljoin(session.url, fileinfo.path)
     logger.info("Requesting file: {}".format(url))
     return requests.get(url, stream=True)
 
@@ -220,7 +227,7 @@ def _write_file_safely(local_path, fileinfo, response):
     except BaseException as e:
         logger.warning("{} interrupted writing {} -- "
                        "cleaning up partial file".format(
-                       e.__class__.__name__, local_path))
+                           e.__class__.__name__, local_path))
         os.remove(local_path)
         raise e
 
@@ -257,8 +264,8 @@ def _update_pbar(pbar, val):
 ###########################################
 # Local and remote file watcher-generators
 
-def watch_local_files(*filters, local_dir="."):
-    list_local = partial(list_local_files, *filters, local_dir=local_dir)
+def watch_local_files(session: Session = Session()):
+    list_local = partial(list_local_files, session)
     old_files = new_files = set(list_local())
     while True:
         yield new_files - old_files, new_files
@@ -266,55 +273,60 @@ def watch_local_files(*filters, local_dir="."):
         new_files = set(list_local())
 
 
-def watch_remote_files(*filters, remote_dir="."):
-    command.memory_changed()  # clear change status to start
-    list_remote = partial(command.list_files,
-                          *filters, remote_dir=remote_dir)
+def watch_remote_files(session: Session = Session()):
+    command.memory_changed(session)  # clear change status to start
+    list_remote = partial(command.list_files, session)
     old_files = new_files = set(list_remote())
     while True:
         yield new_files - old_files, new_files
         old_files = new_files
-        if command.memory_changed():
+        if command.memory_changed(session):
             new_files = set(list_remote())
 
 
 #####################################################
 # Synchronize ONCE in the UP direction (to FlashAir)
 
-def up_by_all(*filters, local_dir=".", remote_dir=DEFAULT_REMOTE_DIR, **_):
-    files = list_local_files(*filters, local_dir=local_dir)
-    up_by_files(list(files), remote_dir=remote_dir)
+def up_by_all(session: Session = Session(), count: Optional[int] = None):
+    files = list(list_local_files(session))
+    if count is not None:
+        files = files[-count:]
+    up_by_files(list(files), session=session)
 
 
-def up_by_files(to_sync, remote_dir=DEFAULT_REMOTE_DIR, remote_files=None):
+def up_by_files(to_sync: List[FileInfo] = [],
+                remote_files: Optional[Dict[str, FileInfo]] = None,
+                session: Session = Session()):
     """Sync a given list of local files to `remote_dir` dir"""
     if remote_files is None:
-        remote_files = command.map_files_raw(remote_dir=remote_dir)
+        remote_files = command.map_files_raw(session)
     for local_file in to_sync:
-        _sync_local_file(local_file, remote_dir, remote_files)
+        _sync_local_file(local_file, remote_files, session)
 
 
-def up_by_time(*filters, local_dir=".", remote_dir=DEFAULT_REMOTE_DIR, count=1):
+def up_by_time(session: Session = Session(), count=1):
     """Sync most recent file by date, time attribues"""
-    remote_files = command.map_files_raw(remote_dir=remote_dir)
-    local_files = list_local_files(*filters, local_dir=local_dir)
+    remote_files = command.map_files_raw(session)
+    local_files = list_local_files(session)
     most_recent = sorted(local_files, key=lambda f: f.datetime)
     to_sync = most_recent[-count:]
     _notify_sync(Direction.up, to_sync)
-    up_by_files(to_sync[::-1], remote_dir, remote_files)
+    up_by_files(session, to_sync[::-1], remote_files)
 
 
-def up_by_name(*filters, local_dir=".", remote_dir=DEFAULT_REMOTE_DIR, count=1):
+def up_by_name(session: Session = Session(), count=1):
     """Sync files whose filename attribute is highest in alphanumeric order"""
-    remote_files = command.map_files_raw(remote_dir=remote_dir)
-    local_files = list_local_files(*filters, local_dir=local_dir)
+    remote_files = command.map_files_raw(session)
+    local_files = list_local_files(session)
     greatest = sorted(local_files, key=lambda f: f.filename)
     to_sync = greatest[-count:]
     _notify_sync(Direction.up, to_sync)
-    up_by_files(to_sync[::-1], remote_dir, remote_files)
+    up_by_files(session, to_sync[::-1], remote_files)
 
 
-def _sync_local_file(local_file_info, remote_dir, remote_files):
+def _sync_local_file(local_file_info: SimpleFileInfo,
+                     remote_files: Dict[str, FileInfo],
+                     session: Session = Session()):
     local_name = local_file_info.filename
     local_size = local_file_info.size
     if local_name in remote_files:
@@ -323,58 +335,63 @@ def _sync_local_file(local_file_info, remote_dir, remote_files):
         if local_size == remote_size:
             logger.info(
                 "Skipping '{}' already exists on SD card".format(
-                local_name))
+                    local_name))
         else:
             logger.warning(
                 "Removing remote file {}: "
                 "local size {} != remote size {}".format(
-                local_name, local_size, remote_size))
-            upload.delete_file(remote_file_info.path)
-            _stream_from_file(local_file_info, remote_dir)
+                    local_name, local_size, remote_size))
+            upload.delete_file(remote_file_info.path, session)
+            _stream_from_file(local_file_info, session)
     else:
-        _stream_from_file(local_file_info, remote_dir)
+        _stream_from_file(session, local_file_info)
 
 
-def _stream_from_file(fileinfo, remote_dir):
+def _stream_from_file(fileinfo: SimpleFileInfo,
+                      session: Session = Session()):
     logger.info("Uploading local file {} to {}".format(
-                fileinfo.path, remote_dir))
-    _upload_file_safely(fileinfo, remote_dir)
+                fileinfo.path, session.remote_dir))
+    _upload_file_safely(fileinfo, session)
 
 
-def _upload_file_safely(fileinfo, remote_dir):
+def _upload_file_safely(fileinfo: SimpleFileInfo,
+                        session: Session = Session()):
     """attempts to upload a local file to FlashAir,
     tries to remove the remote file if interrupted by any error"""
     try:
-        upload.upload_file(fileinfo.path, remote_dir=remote_dir)
+        upload.upload_file(fileinfo.path, session)
     except BaseException as e:
         logger.warning("{} interrupted writing {} -- "
                        "cleaning up partial remote file".format(
-                       e.__class__.__name__, fileinfo.path))
-        upload.delete_file(fileinfo.path)
+                           e.__class__.__name__, fileinfo.path))
+        upload.delete_file(fileinfo.path, session)
         raise e
 
 
-def list_local_files(*filters, local_dir="."):
-    all_entries = scandir(local_dir)
+def list_local_files(
+        session: Session = Session()) -> Iterable[SimpleFileInfo]:
+    all_entries = scandir(session.local_dir)
     file_entries = (e for e in all_entries if e.is_file())
     for entry in file_entries:
         stat = entry.stat()
         size = stat.st_size
         datetime = arrow.get(stat.st_mtime)
-        path = str(Path(local_dir, entry.name))
-        info = SimpleFileInfo(local_dir, entry.name, path, size, datetime)
-        if all(filt(info) for filt in filters):
+        path = str(Path(session.local_dir, entry.name))
+        info = SimpleFileInfo(session.local_dir, entry.name, path,
+                              size, datetime)
+        if all(filt(info) for filt in session.filters):
             yield info
 
 
-def list_local_files_raw(*filters, local_dir="."):
-    all_entries = scandir(local_dir)
+def list_local_files_raw(
+        session: Session = Session()) -> Iterable[RawFileInfo]:
+    all_entries = scandir(session.local_dir)
     all_files = (e for e in all_entries if e.is_file() and
-                 all(filt(e) for filt in filters))
+                 all(filt(e) for filt in session.filters))
     for entry in all_files:
-        path = str(Path(local_dir, entry.name))
-        yield RawFileInfo(local_dir, entry.name, path, entry.stat().st_size)
-
+        path = str(Path(session.local_dir, entry.name))
+        yield RawFileInfo(session.local_dir, entry.name, path,
+                          entry.stat().st_size)
 
 
 def _notify_sync(direction, files):
@@ -386,5 +403,4 @@ def _notify_sync(direction, files):
 def _notify_sync_ready(num_old_files, from_dir, to_dir):
     logger.info("Ready to sync new files from {} to {} "
                 "({:d} existing files ignored)".format(
-                from_dir, to_dir, num_old_files))
-
+                    from_dir, to_dir, num_old_files))

--- a/tfatool/util.py
+++ b/tfatool/util.py
@@ -1,7 +1,6 @@
 import arrow
 
-from itertools import groupby
-from operator import attrgetter, itemgetter
+from operator import attrgetter
 
 
 def parse_datetime(datetime_input):
@@ -15,7 +14,7 @@ def parse_datetime(datetime_input):
     time_vals = _parse_time(time_els)
     vals = tuple(date_vals) + tuple(time_vals)
     return arrow.get(*vals)
-    
+
 
 def _split_datetime(datetime_input):
     dt_input = datetime_input.split(" ")
@@ -73,7 +72,7 @@ def _parse_date(date_els):
 
 def _parse_time(time_els):
     if len(time_els) == 1:
-        time_vals = 0, 0, 0 
+        time_vals = 0, 0, 0
     elif len(time_els) == 2:
         time_vals = time_els + (0,)  # assumed H:M
     elif len(time_els) == 3:
@@ -81,7 +80,7 @@ def _parse_time(time_els):
     else:
         raise ValueError("Time '{}' can't be understood".format(time_els))
     return map(int, time_vals)
-        
+
 
 def _is_year(element):
     return len(element) == 4
@@ -92,7 +91,7 @@ def fmt_file_rows(files):
     for f in files:
         fname = f.filename
         fdate = f.datetime.format("YYYY-MM-DD")
-        ftime = f.datetime.format("HH:mm") 
+        ftime = f.datetime.format("HH:mm")
         size = "{:> 3.02f}".format(f.size / 10**6)
         human = f.datetime.humanize()
         yield fname, fdate, ftime, size, human
@@ -108,4 +107,3 @@ def get_size_units(nbytes):
     else:
         units, val = "B", nbytes
     return val, units
-


### PR DESCRIPTION
# A `Session` object to keep connection state
The `session.Session` object keeps track of:
    - Which filters are applied
    - What the URL of the FlashAir device is (this is for #12)
    - What the local directory is
    - What the remote directory is

It's not clear how useful this will be to users of `tfatool`, but this object also provides some context managers so you can write code like:

```python
session = session.Session(url="http://10.10.3.2", filters=(lambda f: f.size < 10000,))
with session.filtered(lambda f: f.filename.endswith(".jpg")):
    ...  # upload, download, sync, or whatever with the JPEG filter
    ...  # note that the original size filter is no longer applied
with session.added_filters(lambda f: f.filename.endswith(".jpg")):
    ...  # upload, download, sync, or whatever withe the JPEG filter
    ... # note that the original size filter is still applied
with session.transferring_to(local_dir="~/Trash/"):
    ...  # temporarily throw things in the trash
    ...  # note that both local_dir and remote_dir can be specified (or omitted)
```

## Note that this means you have to pass `Session` _everywhere_
Functions in the `sync`, `command`, `upload`, and `config` modules now take a `Session` object to gather all the info they need about filters, local/remote directories, and the FlashAir device URL.

# A call for testing
If anybody's listening, this branch needs functional testing. The procedure goes like this:

1. Install this branch: `git fetch` followed by `git checkout session`
2. Run the functional tests: `pytest test_functional.py -s -v`

Any help is hugely appreciated. I can't do it 'cause I've lost my FlashAir device.